### PR TITLE
Add imagick

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -3,7 +3,12 @@ FROM php:8.2-apache
 
 # Install system dependencies. We want MySQL CLI so we can communicate with container on socket via Docker from outside.
 RUN apt-get update && \
-    apt-get install -y git default-mysql-client dos2unix
+    apt-get install -y --no-install-recommends default-mysql-client dos2unix vim-tiny
+
+# ImageMagick is required for some RSVC features (e.g. C.3.24.1700)
+# We use this tool to install it because of the "no installation candidate" error mentioned here: https://hub.docker.com/_/php
+COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/local/bin/
+RUN install-php-extensions imagick
 
 # Install PHP extensions.  This is key because REDCap uses MySQLi
 RUN docker-php-ext-install -j$(nproc) mysqli

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -5,13 +5,13 @@ FROM php:8.2-apache
 RUN apt-get update && \
     apt-get install -y --no-install-recommends default-mysql-client dos2unix vim-tiny
 
-# ImageMagick is required for some RSVC features (e.g. C.3.24.1700)
-# We use this tool to install it because of the "no installation candidate" error mentioned here: https://hub.docker.com/_/php
+# Use this utility to install php extensions, since docker-php-ext-install doesn't support them all.
 COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/local/bin/
-RUN install-php-extensions imagick
 
-# Install PHP extensions.  This is key because REDCap uses MySQLi
-RUN docker-php-ext-install -j$(nproc) mysqli
+# MySQLi is required for REDCap
+# ImageMagick is required for some RSVC features (e.g. C.3.24.1700).  We use this tool to install it because of the "no installation candidate" error mentioned here: https://hub.docker.com/_/php
+# Zip extension is currently used to download composer packages during cloud builds (faster than using git), but we might also use it in some actual tests down the road.
+RUN install-php-extensions mysqli imagick zip
 
 # Configure Mailhog
 RUN curl -Lsf 'https://storage.googleapis.com/golang/go1.19.4.linux-amd64.tar.gz' | tar -C '/usr/local' -xvzf -


### PR DESCRIPTION
@kcmcg, the main goal here was to install image magick since it is required for the `Consent Form (Inline PDF)` option to appear in REDCap's UI.  I made a few improvements to things I touched along the way.  The most important one was installing the php zip extension which makes our composer install cloud step take 2 seconds instead of 45.  It was using git previously to checkout packages via their source.

These build results confirm that this PR works.  The one additional failure is an intermittently failing test with a timing issue (not related to this change):
![image](https://github.com/user-attachments/assets/143137b4-0e58-495c-b246-2c12196ff5d6)
 